### PR TITLE
Set input border to white

### DIFF
--- a/semantic/src/themes/sharegate/elements/input.variables
+++ b/semantic/src/themes/sharegate/elements/input.variables
@@ -1,3 +1,5 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+@borderColor: white;


### PR DESCRIPTION
According to Sharegate design, input borders should be white.