### PR TITLE
Set inherit to allow setting custom text color when using this component

### DIFF
--- a/semantic/src/themes/sharegate/modules/checkbox.variables
+++ b/semantic/src/themes/sharegate/modules/checkbox.variables
@@ -6,9 +6,9 @@
 @checkboxColor: @textColor;
 @checkboxLineHeight: @checkboxSize;
 
-
 /* Label */
 @labelDistance: 1.5em; /* 26px @ 14/em */
+@labelColor: inherit;
 
 /* Checkbox */
 @checkboxBackground: @white;


### PR DESCRIPTION
This will allow, for example, using tachyons atomic classes to set the text color.